### PR TITLE
Require stable version of GO! AOP instead of dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
            }
        },
     "require": {
-        "lisachenko/go-aop-php": "0.4.x-dev"
+        "lisachenko/go-aop-php": "~0.4"
     },
     "require-dev": {
         "codeception/codeception": "@stable",


### PR DESCRIPTION
Т.к. требуемая версия 0.4 уже выпущена - будет отлично ссылаться на неё, а не на разрабатываемую 0.4.x-dev
