### PR TITLE
make getCallsForMethod public

### DIFF
--- a/src/AspectMock/Proxy/ClassProxy.php
+++ b/src/AspectMock/Proxy/ClassProxy.php
@@ -31,6 +31,13 @@ use PHPUnit_Framework_Assert as a;
  * $userModel->className; // UserModel
  * ?>
  * ```
+ *
+ * Also, you can get the list of calls for a specific method.
+ *
+ * ```php
+ * $user = test::double('UserModel');
+ * $user->someMethod('arg1', 'arg2');
+ * $user->getCallsForMethod('someMethod') // [ ['arg1', 'arg2'] ]
  */
 class ClassProxy extends Verifier  {
 
@@ -44,7 +51,7 @@ class ClassProxy extends Verifier  {
 
     }
 
-    protected function getCallsForMethod($method)
+    public function getCallsForMethod($method)
     {
         $calls = Registry::getClassCallsFor($this->className);
         return isset($calls[$method])

--- a/src/AspectMock/Proxy/InstanceProxy.php
+++ b/src/AspectMock/Proxy/InstanceProxy.php
@@ -43,6 +43,12 @@ use AspectMock\Test;
  * $user->class->verifyInvoked('setName');
  * ?>
  * ```
+ * Also, you can get the list of calls for a specific method.
+ *
+ * ```php
+ * $user = test::double(new UserModel);
+ * $user->someMethod('arg1', 'arg2');
+ * $user->getCallsForMethod('someMethod') // [ ['arg1', 'arg2'] ]
  *
  * Class InstanceVerifier
  * @package AspectMock\Core
@@ -74,7 +80,7 @@ class InstanceProxy extends Verifier {
         return $this->instance;
     }
     
-    protected function getCallsForMethod($method)
+    public function getCallsForMethod($method)
     {
         $calls = Registry::getInstanceCallsFor($this->instance);
         return isset($calls[$method])

--- a/src/AspectMock/Proxy/Verifier.php
+++ b/src/AspectMock/Proxy/Verifier.php
@@ -24,7 +24,7 @@ abstract class Verifier {
 
     protected $neverInvoked = "Expected %s not to be invoked but it was.";
 
-    abstract protected function getCallsForMethod($method);
+    abstract public function getCallsForMethod($method);
 
     protected function callSyntax($method)
     {


### PR DESCRIPTION
For complex arguments matching it would be useful to be able to call `getCallsForMethod()` instead of do the exact matching when using `verifyInvoked('method', [ ... ])`.
