### PR TITLE
Add Symfony/Finder as a dependency for the project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
        },
     "require": {
         "php": ">=5.4.0",
-        "lisachenko/go-aop-php": "0.5.*"
+        "lisachenko/go-aop-php": "0.5.*",
+        "symfony/finder": "~2.4"
     },
     "require-dev": {
         "codeception/codeception": "~2.0",


### PR DESCRIPTION
AspectMock/Kernel.php uses "use Symfony\Component\Finder\Finder;".

If AspectMock is used as a standalone project this dependency is needed.