### PR TITLE
Add license entry in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "codeception/aspect-mock",
     "description": "Experimental Mocking Framework powered by Aspects",
+    "license": "MIT",
     "authors": [
         {
             "name": "Michael Bodnarchuk",


### PR DESCRIPTION
This project includes a LICENSE file, but does not list that license in the composer.json file. This PR adds the MIT license to composer.json, which will also enable the license to be correctly reported on packagist.org.