### PR TITLE
Replace return with yield when docComments returns Generator

### DIFF
--- a/src/AspectMock/Intercept/BeforeMockTransformer.php
+++ b/src/AspectMock/Intercept/BeforeMockTransformer.php
@@ -80,6 +80,10 @@ class BeforeMockTransformer extends WeavingTransformer
                     $beforeDefinition = $method->isStatic()
                         ? $this->beforeStatic
                         : $this->before;
+                    // replace return with yield when doccomment shows it returns a Generator
+                    if(stripos($method->getDocComment(), '@return \Generator') !== false) {
+                        $beforeDefinition = str_replace('return', 'yield', $beforeDefinition);
+                    }
                     $reflectedParams = $method->getParameters();
 
                     $params = [];


### PR DESCRIPTION
After implementing AspectMock to make some nicer tests in part of my suite, other part of my suite started to fail due to using Generators. After searching through the issues (#50) was poking around a bit in the code to find a solution. This does work for me, but you need to make sure the DocComment is properly formatted. 

There might be a better solution, by really inspecting the method signature, but I couldn't find out so quickly how that should be done. If anyone has a hint, feel free to help me on the right track. Else this could be an option to merge.