### PR TITLE
more consistent namespace handling

### DIFF
--- a/src/AspectMock/Core/Mocker.php
+++ b/src/AspectMock/Core/Mocker.php
@@ -128,7 +128,7 @@ class Mocker implements Aspect {
         if (!array_key_exists($method_name,$params)) return false;
         return $params;
     }
-    
+
     protected function stub(MethodInvocation $invocation, $params)
     {
         $name = $invocation->getMethod();
@@ -192,6 +192,7 @@ class Mocker implements Aspect {
 
     public function registerFunc($namespace, $func, $body)
     {
+        $namespace = ltrim($namespace,'\\');
         if (!function_exists("$namespace\\$func")) {
             $injector = new FunctionInjector($namespace, $func);
             $injector->save();

--- a/src/AspectMock/Core/Registry.php
+++ b/src/AspectMock/Core/Registry.php
@@ -37,6 +37,7 @@ class Registry {
 
     static function getClassCallsFor($class)
     {
+        $class = ltrim($class,'\\');
         return isset(self::$classCalls[$class])
             ? self::$classCalls[$class]
             : [];
@@ -52,6 +53,7 @@ class Registry {
 
     static function getFuncCallsFor($func)
     {
+        $func = ltrim($func,'\\');
         return isset(self::$funcCalls[$func]) ? self::$funcCalls[$func] : [];
     }
 

--- a/tests/unit/FunctionInjectorTest.php
+++ b/tests/unit/FunctionInjectorTest.php
@@ -59,6 +59,18 @@ class FunctionInjectorTest extends \Codeception\TestCase\Test
         $func->verifyNeverInvoked(['hee']);
     }
 
+    public function testVerifierFullyQualifiedNamespace()
+    {
+        $func = test::func('\demo', 'strlen', 10);
+        expect(strlen('hello'))->equals(10);
+        $func->verifyInvoked();
+        $func->verifyInvoked(['hello']);
+        $func->verifyInvokedOnce();
+        $func->verifyInvokedOnce(['hello']);
+        $func->verifyInvokedMultipleTimes(1, ['hello']);
+        $func->verifyNeverInvoked(['hee']);
+    }
+
     public function testFailedVerification()
     {
         $this->setExpectedException('PHPUnit_Framework_ExpectationFailedException');
@@ -68,4 +80,3 @@ class FunctionInjectorTest extends \Codeception\TestCase\Test
     }
 
 }
-

--- a/tests/unit/testDoubleTest.php
+++ b/tests/unit/testDoubleTest.php
@@ -26,6 +26,21 @@ class testDoubleTest extends \Codeception\TestCase\Test
         });
     }
 
+    public function testDoubleFullyQualifiedClass()
+    {
+        $user = test::double('\demo\UserModel', ['save' => null]);
+        (new demo\UserModel())->save();
+        $user->verifyInvoked('save');
+        \demo\UserModel::tableName();
+        \demo\UserModel::tableName();
+        $user->verifyInvokedMultipleTimes('tableName',2);
+
+        $this->specify('disabling all methods', function() use ($user) {
+            test::methods($user, []);
+            verify(\demo\UserModel::tableName())->null();
+        });
+    }
+
     public function testDoubleObject()
     {
         $user = new demo\UserModel();
@@ -68,7 +83,7 @@ class testDoubleTest extends \Codeception\TestCase\Test
             $this->any->that = 'xxx';
            $this->assertInstanceOf('AspectMock\Proxy\Anything', $this->any->this->that->another);
         });
-        
+
         $this->specify('can be used as array', function() {
             $this->any['has keys'];
             unset($this->any['this']);


### PR DESCRIPTION
The expectation for AspectMock functions seems to be that all namespaces are specified relative to the root namespace, and so it is not necessary to fully qualify namespaces. In certain cases, however, users will naturally do so.

Previous behavior when passing a fully qualified namespace into `Test::double` or `Test::func`...
`Test::double` - mocking occurs as usual, however the registry reports that no calls were ever made.
`Test::func` - mocking does not properly occur.

There was already a line for stripping the leading backslash in `Mocker::registerClass` however it was not present in `Mocker::registerFunc` or either of the relevant lookup functions in `Registry`.
To fix the behavior, I propagated that cleaning line into all 4 of these locations.

It is possible that there are other places which should have this cleaning, however I have not looked through in detail.