### PR TITLE
Fix counting of dynamic class methods

### DIFF
--- a/src/AspectMock/Core/Mocker.php
+++ b/src/AspectMock/Core/Mocker.php
@@ -10,6 +10,7 @@ class Mocker implements Aspect {
     protected $objectMap = [];
     protected $funcMap = [];
     protected $methodMap = ['__call', '__callStatic'];
+    protected $dynamicMethods = ['__call', '__callStatic'];
 
     public function fakeMethodsAndRegisterCalls($class, $declaredClass, $method, $params, $static)
     {
@@ -25,6 +26,12 @@ class Mocker implements Aspect {
             $invocation->isStatic($static);
             $invocation->setDeclaredClass($declaredClass);
             $result = $this->invokeFakedMethods($invocation);
+        }
+
+        // Record actual method called, not faked method.
+        if (in_array($method, $this->dynamicMethods)) {
+            $method = array_shift($params);
+            $params = array_shift($params);
         }
 
         if (!$static) {

--- a/tests/_data/demo/UserService.php
+++ b/tests/_data/demo/UserService.php
@@ -15,6 +15,12 @@ class UserService {
         $user->save();
     }
 
+    public function renameUser(UserModel $user, $name)
+    {
+        $user->renameUser($name);
+        $user->save();
+    }
+
     public function __call($name, $args)
     {
         if ($name == 'rename') {

--- a/tests/unit/VerifierTest.php
+++ b/tests/unit/VerifierTest.php
@@ -42,4 +42,20 @@ class VerifierTest extends \PHPUnit_Framework_TestCase
         });
     }
 
+    public function testVerifyMagicMethods()
+    {
+        $this->specify('works for class proxy', function() {
+            // Set up user object.
+            double::registerClass("demo\UserModel",
+                                  ['renameUser'=>"Bob Jones", 'save'=>null]);
+            $userProxy = new ClassProxy("demo\UserModel");
+            $user = new UserModel(['name'=>"John Smith"]);
+
+            // Rename the user via magic method.
+            UserService::renameUser($user, "Bob Jones");
+
+            // Assert rename was counted.
+            $userProxy->verifyInvoked('renameUser');
+        });
+    }
 }

--- a/tests/unit/VerifierTest.php
+++ b/tests/unit/VerifierTest.php
@@ -57,5 +57,18 @@ class VerifierTest extends \PHPUnit_Framework_TestCase
             // Assert rename was counted.
             $userProxy->verifyInvoked('renameUser');
         });
+
+        $this->specify('works for instance proxy', function() {
+            // Set up user object.
+            $user = new UserModel(['name'=>"John Smith"]);
+            double::registerObject($user);
+            $user = new InstanceProxy($user);
+
+            // Rename the user via magic method.
+            $user->renameUser("Bob Jones");
+
+            // Assert rename was counted.
+            $user->verifyInvoked('renameUser');
+        });
     }
 }


### PR DESCRIPTION
This should fix #24.

I added a couple tests that fail without this patch and pass with it. Let me know if those tests should be moved somewhere else, or if I should add any more.

Also, let me know if there would be a better way to determine which methods are dynamic (instead of the `$dynamicMethods` attribute that I added to `Mocker.php`).