### PR TITLE
Replacing strpos check with regex

### DIFF
--- a/src/AspectMock/Intercept/BeforeMockTransformer.php
+++ b/src/AspectMock/Intercept/BeforeMockTransformer.php
@@ -81,7 +81,7 @@ class BeforeMockTransformer extends WeavingTransformer
                         ? $this->beforeStatic
                         : $this->before;
                     // replace return with yield when doccomment shows it returns a Generator
-                    if(stripos($method->getDocComment(), '@return \Generator') !== false) {
+                    if (preg_match('/(\@return\s+[\\\]?Generator)/', $method->getDocComment())) {
                         $beforeDefinition = str_replace('return', 'yield', $beforeDefinition);
                     }
                     $reflectedParams = $method->getParameters();


### PR DESCRIPTION
The current strpos check does not account for annotations with Generators not namespaced, replacing this with a regex allows the namespace (root \) to be optional. 