### PR TITLE
Add "license" entry to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "codeception/aspect-mock",
     "description": "Experimental Mocking Framework powered by Aspects",
+    "license": "MIT",
     "authors": [
         {
             "name": "Michael Bodnarchuk",


### PR DESCRIPTION
Using [versioneye](https://www.versioneye.com/user/projects/57c4a6fe968d64004d97620a#tab-dependencies) to analyze Robo, I noticed that this service could not figure out what the license was for codeception/aspect-mock, because there is no license information in the composer.json file.