### PR TITLE
fix verifyNeverInvoked with array params

### DIFF
--- a/src/AspectMock/Proxy/Verifier.php
+++ b/src/AspectMock/Proxy/Verifier.php
@@ -151,7 +151,6 @@ abstract class Verifier {
 
          if (is_array($params)) {
              if (empty($calls)) return;
-             $params = ArgumentsFormatter::toString($params);
              foreach ($calls as $args) {
                  if ($this->onlyExpectedArguments($params, $args) == $params) throw new fail(sprintf($this->neverInvoked, $this->className));
              }

--- a/tests/_data/demo/UserModel.php
+++ b/tests/_data/demo/UserModel.php
@@ -44,6 +44,24 @@ class UserModel {
     }
 
     /**
+     * @param mixed $name
+     */
+    public function setNameAndInfo($name, $info)
+    {
+        $this->name = $name;
+        $this->info = $info;
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getNameAndInfo()
+    {
+        return array($this->name, $this->info);
+    }
+
+    /**
      * @param array $info
      */
     public function setInfo($info)

--- a/tests/unit/VerifierTest.php
+++ b/tests/unit/VerifierTest.php
@@ -74,7 +74,7 @@ class VerifierTest extends \PHPUnit_Framework_TestCase
 
     public function testverifyWithMutliplesParams()
     {
-        $this->specify('works for instance proxy', function() {
+        $this->specify('works for instance proxy', function () {
             // Set up user object.
             $user = new UserModel(['name' => "John Smith"]);
             double::registerObject($user);
@@ -85,20 +85,29 @@ class VerifierTest extends \PHPUnit_Framework_TestCase
 
             // Assert rename was counted.
             $user->verifyInvoked('setName', "Bob Jones");
+            // if verifyInvoked is ok, verifyNeverInvoked have to fail
+            try {
+                $user->verifyNeverInvoked('setName', "Bob Jones");
+                // If i dont fail, my test fail
+                throw new fail('verifyNeverInvoked');
+            } catch (\Exception $e) {}
+
             $user->verifyNeverInvoked('setName', ["Boby Jones"]);
 
             // call function with multiple params
             $user->setNameAndInfo("Bob Jones", "Infos");
 
             // verify
-            $user->verifyInvoked('setNameAndInfo',["Bob Jones", "Infos"]);
+            $user->verifyInvoked('setNameAndInfo', ["Bob Jones", "Infos"]);
 
             // if verifyInvoked is ok, verifyNeverInvoked have to fail
             try {
                 $user->verifyNeverInvoked('setNameAndInfo', ["Bob Jones", "Infos"]);
                 // If i dont fail, my test fail
                 throw new fail('verifyNeverInvoked');
-            } catch (\Exception $e) {}
+            } catch (\Exception $e) {
+
+            }
         });
     }
 }

--- a/tests/unit/VerifierTest.php
+++ b/tests/unit/VerifierTest.php
@@ -71,4 +71,34 @@ class VerifierTest extends \PHPUnit_Framework_TestCase
             $user->verifyInvoked('renameUser');
         });
     }
+
+    public function testverifyWithMutliplesParams()
+    {
+        $this->specify('works for instance proxy', function() {
+            // Set up user object.
+            $user = new UserModel(['name' => "John Smith"]);
+            double::registerObject($user);
+            $user = new InstanceProxy($user);
+
+            // Rename the user
+            $user->setName("Bob Jones");
+
+            // Assert rename was counted.
+            $user->verifyInvoked('setName', "Bob Jones");
+            $user->verifyNeverInvoked('setName', ["Boby Jones"]);
+
+            // call function with multiple params
+            $user->setNameAndInfo("Bob Jones", "Infos");
+
+            // verify
+            $user->verifyInvoked('setNameAndInfo',["Bob Jones", "Infos"]);
+
+            // if verifyInvoked is ok, verifyNeverInvoked have to fail
+            try {
+                $user->verifyNeverInvoked('setNameAndInfo', ["Bob Jones", "Infos"]);
+                // If i dont fail, my test fail
+                throw new fail('verifyNeverInvoked');
+            } catch (\Exception $e) {}
+        });
+    }
 }


### PR DESCRIPTION
This is a fix for verifyNeverInvoked when you use it with array (for function with multiple params)

Before the fix, something like this worked :
```
$user->verifyInvoked('setNameAndInfo',["Bob Jones", "Infos"]);
$user->verifyNeverInvoked('setNameAndInfo', ["Bob Jones", "Infos"]);
```
