### PR TITLE
入力値チェックの比較が不完全

### DIFF
--- a/src/AspectMock/Proxy/Verifier.php
+++ b/src/AspectMock/Proxy/Verifier.php
@@ -151,17 +151,17 @@ abstract class Verifier {
         $calls = $this->getCallsForMethod($name);
         $separator = $this->callSyntax($name);
 
-         if (is_array($params)) {
-             if (empty($calls)) return;
-             $params = ArgumentsFormatter::toString($params);
-             foreach ($calls as $args) {
-                 if ($this->onlyExpectedArguments($params, $args) === $params) {
-                     throw new fail(sprintf($this->neverInvoked, $this->className));
-                 }
-             }
-             return;
-         }
-         if (count($calls)) throw new fail(sprintf($this->neverInvoked, $this->className.$separator.$name));        
+        if (is_array($params)) {
+            if (empty($calls)) return;
+            $params = ArgumentsFormatter::toString($params);
+            foreach ($calls as $args) {
+                if ($this->onlyExpectedArguments($params, $args) === $params) {
+                    throw new fail(sprintf($this->neverInvoked, $this->className));
+                }
+            }
+            return;
+        }
+        if (count($calls)) throw new fail(sprintf($this->neverInvoked, $this->className.$separator.$name));
     }
 
 }

--- a/src/AspectMock/Proxy/Verifier.php
+++ b/src/AspectMock/Proxy/Verifier.php
@@ -114,7 +114,9 @@ abstract class Verifier {
         if (is_array($params)) {
             $equals = 0;
             foreach ($calls as $args) {
-                if ($this->onlyExpectedArguments($params, $args) === $params) $equals++;
+                if ($this->onlyExpectedArguments($params, $args) === $params) {
+                    $equals++;
+                }
             }
             if ($equals == $times) return;
             $params = ArgumentsFormatter::toString($params);
@@ -153,7 +155,9 @@ abstract class Verifier {
              if (empty($calls)) return;
              $params = ArgumentsFormatter::toString($params);
              foreach ($calls as $args) {
-                 if ($this->onlyExpectedArguments($params, $args) === $params) throw new fail(sprintf($this->neverInvoked, $this->className));
+                 if ($this->onlyExpectedArguments($params, $args) === $params) {
+                     throw new fail(sprintf($this->neverInvoked, $this->className));
+                 }
              }
              return;
          }

--- a/src/AspectMock/Proxy/Verifier.php
+++ b/src/AspectMock/Proxy/Verifier.php
@@ -152,7 +152,9 @@ abstract class Verifier {
         $separator = $this->callSyntax($name);
 
         if (is_array($params)) {
-            if (empty($calls)) return;
+            if (empty($calls)) {
+                return;
+            }
             $params = ArgumentsFormatter::toString($params);
             foreach ($calls as $args) {
                 if ($this->onlyExpectedArguments($params, $args) === $params) {
@@ -161,7 +163,9 @@ abstract class Verifier {
             }
             return;
         }
-        if (count($calls)) throw new fail(sprintf($this->neverInvoked, $this->className.$separator.$name));
+        if (count($calls)) {
+            throw new fail(sprintf($this->neverInvoked, $this->className.$separator.$name));
+        }
     }
 
 }

--- a/src/AspectMock/Proxy/Verifier.php
+++ b/src/AspectMock/Proxy/Verifier.php
@@ -114,7 +114,7 @@ abstract class Verifier {
         if (is_array($params)) {
             $equals = 0;
             foreach ($calls as $args) {
-                if ($this->onlyExpectedArguments($params, $args) == $params) $equals++;
+                if ($this->onlyExpectedArguments($params, $args) === $params) $equals++;
             }
             if ($equals == $times) return;
             $params = ArgumentsFormatter::toString($params);
@@ -153,7 +153,7 @@ abstract class Verifier {
              if (empty($calls)) return;
              $params = ArgumentsFormatter::toString($params);
              foreach ($calls as $args) {
-                 if ($this->onlyExpectedArguments($params, $args) == $params) throw new fail(sprintf($this->neverInvoked, $this->className));
+                 if ($this->onlyExpectedArguments($params, $args) === $params) throw new fail(sprintf($this->neverInvoked, $this->className));
              }
              return;
          }


### PR DESCRIPTION
以下の2箇所は `==` ではなく `===` で比較しないと正しく無いのにテストをすり抜けるパターンが出てしまう
* https://github.com/Codeception/AspectMock/blob/cb0f376/src/AspectMock/Proxy/Verifier.php#L117
* https://github.com/Codeception/AspectMock/blob/cb0f376/src/AspectMock/Proxy/Verifier.php#L156

下記は修正されているので、恐らくバグだろう
* https://github.com/Codeception/AspectMock/blob/cb0f376/src/AspectMock/Proxy/Verifier.php#L68


phpは0と文字列の比較は、`==`だとtrueになってしまう
```
var_dump(0=="文字列");  //bool(true)
```

例えば引数の配列に0が入っていて、比較対象を文字列にした場合問題が起きる
```
$args = [1,2, "文字列"] ;
$params = [1,2, 0] 
var_dump($this->onlyExpectedArguments($params, $args) == $params);  //bool(true)

// 同じじゃねーだろ！！
```
