### PR TITLE
Add missing type hints and parameter types to FuncProxy

### DIFF
--- a/src/AspectMock/Proxy/FuncProxy.php
+++ b/src/AspectMock/Proxy/FuncProxy.php
@@ -25,8 +25,19 @@ use AspectMock\Core\Registry;
  */
 class FuncProxy
 {
+    /**
+     * @var string
+     */
     protected $func;
+    
+    /**
+     * @var string
+     */
     protected $ns;
+    
+    /**
+     * @var string
+     */
     protected $fullFuncName;
 
     /**
@@ -34,6 +45,10 @@ class FuncProxy
      */
     protected $funcVerifier;
 
+    /**
+     * @param string
+     * @param string
+     */
     public function __construct($namespace, $func)
     {
         $this->func = $func;
@@ -43,34 +58,34 @@ class FuncProxy
     }
 
     /**
-     * @param null $params
+     * @param null|array $params
      */
-    public function verifyInvoked($params = null)
+    public function verifyInvoked(array $params = null)
     {
         $this->funcVerifier->verifyInvoked($this->func, $params);
     }
 
     /**
-     * @param null $params
+     * @param null|array $params
      */
-    public function verifyInvokedOnce($params = null)
+    public function verifyInvokedOnce(array $params = null)
     {
         $this->funcVerifier->verifyInvokedMultipleTimes($this->func, 1, $params);
     }
 
     /**
-     * @param null $params
+     * @param null|array $params
      */
-    public function verifyNeverInvoked($params = null)
+    public function verifyNeverInvoked(array $params = null)
     {
         $this->funcVerifier->verifyNeverInvoked($this->func, $params);
     }
 
     /**
-     * @param $times
-     * @param null $params
+     * @param int        $times
+     * @param null|array $params
      */
-    public function verifyInvokedMultipleTimes($times, $params = null)
+    public function verifyInvokedMultipleTimes($times, array $params = null)
     {
         $this->funcVerifier->verifyInvokedMultipleTimes($this->func, $times, $params);
     }
@@ -84,7 +99,10 @@ class FuncProxy
         return call_user_func_array($this->ns .'\\'.$this->func, func_get_args());
     }
 
-
+    /**
+     * @param string
+     * @return array
+     */
     public function getCallsForMethod($func)
     {
         $calls = Registry::getFuncCallsFor($this->ns . '\\' . $func);

--- a/tests/unit/FunctionInjectorTest.php
+++ b/tests/unit/FunctionInjectorTest.php
@@ -3,7 +3,6 @@ namespace demo;
 
 use AspectMock\Intercept\FunctionInjector;
 use AspectMock\Test as test;
-use Codeception\TestCase;
 
 class FunctionInjectorTest extends \Codeception\TestCase\Test
 {
@@ -11,10 +10,12 @@ class FunctionInjectorTest extends \Codeception\TestCase\Test
      * @var FunctionInjector
      */
     protected $funcInjector;
+
     /**
      * @var FunctionInjector
      */
     protected $funcOptionalParameterInjector;
+
     /**
      * @var FunctionInjector
      */
@@ -101,7 +102,7 @@ class FunctionInjectorTest extends \Codeception\TestCase\Test
     {
         $func = test::func('demo', 'strlen', function() { return 10; });
         expect(strlen('hello'))->equals(10);
-        $func->verifyNeverInvoked('strlen');
+        $func->verifyNeverInvoked();
     }
 
     public function testReferencedParameter()


### PR DESCRIPTION
While working with AspectMock, I saw some missing type hints and comments in `FuncProxy`. To help developers figuring out the correct arguments for the methods, I've added type hints and doc-block comments to the class.

This is helpful, when someone is working directly with the code.