### PR TITLE
don't let GoAOP upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
        },
     "require": {
         "php": ">=5.6.0",
-        "goaop/framework": "^2.0.0",
+        "goaop/framework": "2.1.*",
         "symfony/finder": "~2.4|~3.0|~4.0"
     },
     "require-dev": {


### PR DESCRIPTION
This PR is a proposal to limit the updating of goaop/framework so that the AST streaming issues 

* https://github.com/goaop/framework/issues/363
* https://github.com/Codeception/AspectMock/issues/146

which are not totally resolved in 2.2.

I'd be happy to fix this the "right way" with AOP tokenStreams, but it doesn't look like that code has settled down yet in 2.2, so it seems like wasted effort. 