### PR TITLE
Update AspectMock tranfsformer to the new version of GoAOP, fixes #146

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
        },
     "require": {
         "php": ">=5.6.0",
-        "goaop/framework": "^2.0.0",
+        "goaop/framework": "^2.2.0",
         "symfony/finder": "~2.4|~3.0|~4.0"
     },
     "require-dev": {


### PR DESCRIPTION
This PR updates AspectMock to the newest version of GoAOP 2.2.0 and clean all deprecated parts, switching to the AST model.