### PR TITLE
Forward compatibility with goaop/framework v3

### DIFF
--- a/src/AspectMock/Intercept/BeforeMockTransformer.php
+++ b/src/AspectMock/Intercept/BeforeMockTransformer.php
@@ -11,7 +11,7 @@ class BeforeMockTransformer extends WeavingTransformer
     protected $before = " if ((\$__am_res = __amock_before(\$this, __CLASS__, __FUNCTION__, array(%s), false)) !== __AM_CONTINUE__) return \$__am_res; ";
     protected $beforeStatic = " if ((\$__am_res = __amock_before(get_called_class(), __CLASS__, __FUNCTION__, array(%s), true)) !== __AM_CONTINUE__) return \$__am_res; ";
 
-    public function transform(StreamMetaData $metadata)
+    public function transform(StreamMetaData $metadata): string
     {
         $result        = self::RESULT_ABSTAIN;
         $reflectedFile = new ReflectionFile($metadata->uri, $metadata->syntaxTree);

--- a/src/AspectMock/Kernel.php
+++ b/src/AspectMock/Kernel.php
@@ -56,7 +56,7 @@ class Kernel extends AspectKernel
         include FilterInjectorTransformer::rewrite($file);
     }
 
-    protected function registerTransformers()
+    protected function registerTransformers(): array
     {
         $cachePathManager = $this->getContainer()->get('aspect.cache.path.manager');;
 


### PR DESCRIPTION
In the latest master of `goaop/framework` that will eventually become v3.0.0, there are return types defined for two methods that `AspectMock` extends, making it incompatible. This is a forward compatibility change that shouldn't affect people using AspectMock as long as they have PHP7.0 or newer. AspectMock's requirements call for php 7.0+ anyway.