### PR TITLE
Fix syntax error in PHP 7.1

### DIFF
--- a/src/AspectMock/Kernel.php
+++ b/src/AspectMock/Kernel.php
@@ -21,6 +21,7 @@ class Kernel extends AspectKernel
             $options['excludePaths'] = [];
         }
         $options['debug'] = true;
+        $options['excludePaths'] = [];
         $options['excludePaths'][] = __DIR__;
 
         parent::init($options);


### PR DESCRIPTION
[] operator not supported for strings in PHP 7.1

I initial the variable as array, and put the value then.


```
PHP Fatal error:  Uncaught Error: [] operator not supported for strings in /home/zero/devel/boltics-core/vendor/codeception/aspect-mock/src/AspectMock/Kernel.php:24
Stack trace:
#0 /home/zero/devel/boltics-core/tests/bootstrap.php(9): AspectMock\Kernel->init(Array)
#1 /home/zero/devel/boltics-core/vendor/phpunit/phpunit/src/Util/FileLoader.php(57): include_once('/home/zero/deve...')
#2 /home/zero/devel/boltics-core/vendor/phpunit/phpunit/src/Util/FileLoader.php(45): PHPUnit\Util\FileLoader::load('/home/zero/deve...')
#3 /home/zero/devel/boltics-core/vendor/phpunit/phpunit/src/TextUI/Command.php(1058): PHPUnit\Util\FileLoader::checkAndLoad('/home/zero/deve...')
#4 /home/zero/devel/boltics-core/vendor/phpunit/phpunit/src/TextUI/Command.php(863): PHPUnit\TextUI\Command->handleBootstrap('/home/zero/deve...')
#5 /home/zero/devel/boltics-core/vendor/phpunit/phpunit/src/TextUI/Command.php(173): PHPUnit\TextUI\Command->handleArguments(Array)
#6 /home/zero/devel/boltics-core/vendor/phpunit/phpunit/src/TextUI/Command.php(162): PHPUnit\T in /home/zero/devel/boltics-core/vendor/codeception/aspect-mock/src/AspectMock/Kernel.php on line 24
```