### PR TITLE
AA-2 fixed PHPUnit Framework Exception Undefined offset at  BeforeMoc…

### DIFF
--- a/src/AspectMock/Intercept/BeforeMockTransformer.php
+++ b/src/AspectMock/Intercept/BeforeMockTransformer.php
@@ -69,7 +69,7 @@ class BeforeMockTransformer extends WeavingTransformer
                     $beforeDefinition = sprintf($beforeDefinition, $params);
                     $tokenPosition    = $method->getNode()->getAttribute('startTokenPos');
                     do {
-                        if ($metadata->tokenStream[$tokenPosition][1] === '{') {
+                        if (($metadata->tokenStream[$tokenPosition][1] ?? '') === '{') {
                             $metadata->tokenStream[$tokenPosition][1] .= $beforeDefinition;
                             $result = self::RESULT_TRANSFORMED;
                             break;


### PR DESCRIPTION
This small fix resolved one issue I got recently, I get this error: 
[PHPUnit\Framework\Exception] Undefined offset: 2550 at vendor/codeception/aspect-mock/src/AspectMock/Intercept/BeforeMockTransformer.php:72