### PR TITLE
PHP 8.2 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,10 @@
         "codeception/verify": "^2.2",
         "codeception/specify": "^2.0",
         "consolidation/robo": "^3.0"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "5.0-dev"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,9 @@
            }
        },
     "require": {
-        "php": "^7.4",
-        "goaop/framework": "^3.0",
+        "php": "^8.2",
+        "goaop/framework": "^4.0@dev",
+        "goaop/parser-reflection": "^4.0@dev",
         "phpunit/phpunit": "^9.5",
         "symfony/finder": "^4.4 | ^5.4 | ^6.0"
     },

--- a/src/AspectMock/Intercept/BeforeMockTransformer.php
+++ b/src/AspectMock/Intercept/BeforeMockTransformer.php
@@ -73,8 +73,8 @@ class BeforeMockTransformer extends WeavingTransformer
                     $beforeDefinition = sprintf($beforeDefinition, $params);
                     $tokenPosition    = $method->getNode()->getAttribute('startTokenPos');
                     do {
-                        if (($metadata->tokenStream[$tokenPosition][1] ?? '') === '{') {
-                            $metadata->tokenStream[$tokenPosition][1] .= $beforeDefinition;
+                        if (($metadata->tokenStream[$tokenPosition]->text ?? '') === '{') {
+                            $metadata->tokenStream[$tokenPosition]->text .= $beforeDefinition;
                             $result = self::RESULT_TRANSFORMED;
                             break;
                         }

--- a/src/AspectMock/Kernel.php
+++ b/src/AspectMock/Kernel.php
@@ -8,6 +8,9 @@ use AspectMock\Core\Registry;
 use AspectMock\Intercept\BeforeMockTransformer;
 use Go\Core\AspectContainer;
 use Go\Core\AspectKernel;
+use Go\Core\AdviceMatcher;
+use Go\Core\CachedAspectLoader;
+use Go\Instrument\ClassLoading\CachePathManager;
 use Go\Instrument\ClassLoading\SourceTransformingLoader;
 use Go\Instrument\Transformer\CachingTransformer;
 use Go\Instrument\Transformer\FilterInjectorTransformer;
@@ -61,16 +64,16 @@ class Kernel extends AspectKernel
 
     protected function registerTransformers(): array
     {
-        $cachePathManager = $this->getContainer()->get('aspect.cache.path.manager');
+        $cachePathManager = $this->getContainer()->getService(CachePathManager::class);
 
         $sourceTransformers = [
             new FilterInjectorTransformer($this, SourceTransformingLoader::getId(), $cachePathManager),
             new MagicConstantTransformer($this),
             new BeforeMockTransformer(
                 $this,
-                $this->getContainer()->get('aspect.advice_matcher'),
+                $this->getContainer()->getService(AdviceMatcher::class),
                 $cachePathManager,
-                $this->getContainer()->get('aspect.cached.loader')
+                $this->getContainer()->getService(CachedAspectLoader::class)
             )
         ];
 


### PR DESCRIPTION
Preliminary support for PHP 8.2 by using development versions of `goaop/framework` and `goaop/parser-reflection`.

If you want to test this out right now in your project, use the following in composer.json:
```
 "require-dev": {
    "codeception/aspect-mock": "dev-php8-compatibility",
    "goaop/framework": "@dev",
    "goaop/parser-reflection": "@dev",
  },
  (..)
  "repositories": [
    {
      "type": "vcs",
      "url": "https://github.com/marcovtwout/codeception-aspect-mock.git"
    }
  ]
```