### PR TITLE
When you expect value null to be returned, fake functions was not invoked

### DIFF
--- a/src/AspectMock/Core/Mocker.php
+++ b/src/AspectMock/Core/Mocker.php
@@ -71,7 +71,7 @@ class Mocker implements Aspect
         $fullFuncName = sprintf('%s\%s', $namespace, $function);
         Registry::registerFunctionCall($fullFuncName, $args);
 
-        if (isset($this->funcMap[$fullFuncName])) {
+        if (array_key_exists($fullFuncName, $this->funcMap)) {
             $func = $this->funcMap[$fullFuncName];
             $result = is_callable($func) ? call_user_func_array($func, $args) : $func;
         }

--- a/tests/unit/FunctionInjectorTest.php
+++ b/tests/unit/FunctionInjectorTest.php
@@ -65,6 +65,12 @@ final class FunctionInjectorTest extends \Codeception\TestCase\Test
         verify(strlen('hello'))->equals(10);
     }
 
+    public function testFuncReturnsNull()
+    {
+        test::func('demo', 'strlen', null);
+        verify(strlen('hello'))->equals(null);
+    }
+
     public function testVerifier()
     {
         $func = test::func('demo', 'strlen', 10);


### PR DESCRIPTION
Since "isset" returns false when value does exist in the array, this fixes the check if the mock function registered