### PR TITLE
Fix for BC break in goaop/framework

### DIFF
--- a/src/AspectMock/Intercept/BeforeMockTransformer.php
+++ b/src/AspectMock/Intercept/BeforeMockTransformer.php
@@ -6,6 +6,7 @@ namespace AspectMock\Intercept;
 
 use Go\Aop\Aspect;
 use Go\Instrument\Transformer\StreamMetaData;
+use Go\Instrument\Transformer\TransformerResultEnum;
 use Go\Instrument\Transformer\WeavingTransformer;
 use Go\ParserReflection\ReflectionFile;
 use Go\ParserReflection\ReflectionMethod;
@@ -15,9 +16,9 @@ class BeforeMockTransformer extends WeavingTransformer
     protected string $before = " if ((\$__am_res = __amock_before(\$this, __CLASS__, __FUNCTION__, array(%s), false)) !== __AM_CONTINUE__) return \$__am_res; ";
     protected string $beforeStatic = " if ((\$__am_res = __amock_before(get_called_class(), __CLASS__, __FUNCTION__, array(%s), true)) !== __AM_CONTINUE__) return \$__am_res; ";
 
-    public function transform(StreamMetaData $metadata): string
+    public function transform(StreamMetaData $metadata): TransformerResultEnum
     {
-        $result        = self::RESULT_ABSTAIN;
+        $result        = TransformerResultEnum::RESULT_ABSTAIN;
         $reflectedFile = new ReflectionFile($metadata->uri, $metadata->syntaxTree);
         $namespaces    = $reflectedFile->getFileNamespaces();
 
@@ -75,7 +76,7 @@ class BeforeMockTransformer extends WeavingTransformer
                     do {
                         if (($metadata->tokenStream[$tokenPosition]->text ?? '') === '{') {
                             $metadata->tokenStream[$tokenPosition]->text .= $beforeDefinition;
-                            $result = self::RESULT_TRANSFORMED;
+                            $result = TransformerResultEnum::RESULT_TRANSFORMED;
                             break;
                         }
                         $tokenPosition++;


### PR DESCRIPTION
As of https://github.com/goaop/framework/commit/3b9c486911b23541b615c9aaab18498261a1c405 there is a BC break in the `4.0@dev` version `goaop/framework` that this package has a dependency on.

This pull request updates the `BeforeMockTransformer` class to use the new `TransformerResultEnum` for transformer results, replacing the previous string constants. 

Migration to enum-based transformer result:

* Updated the `transform` method signature in `BeforeMockTransformer` to return `TransformerResultEnum` instead of a string, and replaced all usages of string result constants with their corresponding enum values. [[1]](diffhunk://#diff-1dc68a76f723e2e9c466914137c5408cec945f4124bcb199fa02e147e0ba917eL18-R21) [[2]](diffhunk://#diff-1dc68a76f723e2e9c466914137c5408cec945f4124bcb199fa02e147e0ba917eL78-R79)
* Added the `use Go\Instrument\Transformer\TransformerResultEnum;` import to support the new enum.