### PR TITLE
Fix never return type transformation

### DIFF
--- a/src/AspectMock/Intercept/BeforeMockTransformer.php
+++ b/src/AspectMock/Intercept/BeforeMockTransformer.php
@@ -62,6 +62,10 @@ class BeforeMockTransformer extends WeavingTransformer
                         //TODO remove method_exists($method, 'getReturnType') when support for php5 is dropped
                         $beforeDefinition = str_replace('return $__am_res;', 'return;', $beforeDefinition);
                     }
+                    if ($method->getReturnType() == 'never') {
+                        // Replace return with a NOOP since the method cannot return
+                        $beforeDefinition = str_replace(' return $__am_res;', ';', $beforeDefinition);
+                    }
 
                     $reflectedParams = $method->getParameters();
 

--- a/src/AspectMock/Intercept/BeforeMockTransformer.php
+++ b/src/AspectMock/Intercept/BeforeMockTransformer.php
@@ -58,8 +58,7 @@ class BeforeMockTransformer extends WeavingTransformer
                     if ($method->isGenerator()) {
                         $beforeDefinition = str_replace('return', 'yield', $beforeDefinition);
                     }
-                    if (method_exists($method, 'getReturnType') && $method->getReturnType() == 'void') {
-                        //TODO remove method_exists($method, 'getReturnType') when support for php5 is dropped
+                    if ($method->getReturnType() == 'void') {
                         $beforeDefinition = str_replace('return $__am_res;', 'return;', $beforeDefinition);
                     }
                     if ($method->getReturnType() == 'never') {


### PR DESCRIPTION
I originally thought this was a `goap/framework` issue and so [raised an issue](https://github.com/goaop/framework/issues/514) there as that's what the stack trace indicated. 

It turns out that the problem is caused by AspectMock not checking for the `never` return type before inserting a `return` statement. I'm not sure what the appropriate logic should be, but removing the return statement entirely fixes the fatal error.

I also took care of some house keeping removing the extra check for `getReturnType` now that PHP 5 is no longer supported.