### PR TITLE
Fix callable syntax for PHP 8.2

### DIFF
--- a/src/AspectMock/Util/ArgumentsFormatter.php
+++ b/src/AspectMock/Util/ArgumentsFormatter.php
@@ -10,7 +10,7 @@ final class ArgumentsFormatter
 {
     public static function toString($args): string
     {
-        return implode(',',array_map('self::format', $args));
+        return implode(',',array_map([self::class, 'format'], $args));
     }
 
     protected static function format($arg)


### PR DESCRIPTION
The ArgumentsFormatter currently fails in PHP 8.2+ with `Use of "self" in callables is deprecated`. This PR uses the new syntax which allows IDEs to pick up references.