### PR TITLE
Fixed for current version of goaop

### DIFF
--- a/codeception.yml
+++ b/codeception.yml
@@ -3,6 +3,7 @@ paths:
     log: tests/_log
     data: tests/_data
     helpers: tests/_helpers
+    output: output
 bootstrap: _bootstrap.php
 settings:
     suite_class: \PHPUnit_Framework_TestSuite

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
         "goaop/framework": "^4.0@dev",
         "goaop/parser-reflection": "^4.0@dev",
         "phpunit/phpunit": "^9.5",
-        "symfony/finder": "^4.4 | ^5.4 | ^6.0"
+        "symfony/finder": "^4.4 | ^5.4 | ^6.0 | ^7.4"
     },
     "require-dev": {
-        "codeception/codeception": "^4.1",
+        "codeception/codeception": "^5.1",
         "codeception/verify": "^2.2",
         "codeception/specify": "^2.0",
-        "consolidation/robo": "^3.0"
+        "consolidation/robo": "^5.0"
     },
     "extra": {
         "branch-alias": {

--- a/src/AspectMock/Intercept/FunctionInjector.php
+++ b/src/AspectMock/Intercept/FunctionInjector.php
@@ -56,6 +56,7 @@ EOF;
     public function getParameterDeclaration(\ReflectionParameter $parameter, $internal)
     {
         $text = (string)$parameter;
+
         if (preg_match('#Parameter\s\#\d+\s\[\s<(required|optional)>(.*)(\sor NULL)(.*)\s]#', $text, $match)) {
             $text = $match[2].$match[4];
         } elseif (preg_match('#Parameter\s\#\d+\s\[\s<(required|optional)>\s(.*)\s]#', $text, $match)) {
@@ -65,7 +66,9 @@ EOF;
         }
 
         if ($internal && $parameter->isOptional()) {
-            $text .= "=NULL";
+            if (!str_contains($text, "=")) {
+              $text .= "=NULL";
+            }
         }
 
         return $text;
@@ -136,4 +139,4 @@ EOF;
     {
         $this->template = str_replace(sprintf('{{%s}}', $var), $value, $this->template);
     }
-} 
+}

--- a/src/AspectMock/Kernel.php
+++ b/src/AspectMock/Kernel.php
@@ -34,7 +34,7 @@ class Kernel extends AspectKernel
         parent::init($options);
     }
 
-    protected function configureAop(AspectContainer $container)
+    protected function configureAop(AspectContainer $container): void
     {
         Registry::setMocker(new Core\Mocker);
     }

--- a/tests/unit/ClassProxyTest.php
+++ b/tests/unit/ClassProxyTest.php
@@ -6,7 +6,7 @@ use AspectMock\Proxy\ClassProxy;
 use AspectMock\Test as test;
 use Codeception\Specify;
 
-final class ClassProxyTest extends \Codeception\TestCase\Test
+final class ClassProxyTest extends \Codeception\Test\Unit
 {
 
     use Specify;
@@ -46,16 +46,16 @@ final class ClassProxyTest extends \Codeception\TestCase\Test
     {
         $this->class = test::double('demo\UserModel');
 
-        $this->specify('instance can be created from a class proxy', function() {
+        //$this->specify('instance can be created from a class proxy', function() {
             $user = $this->class->construct(['name' => 'davert']);
             verify($user->getName())->equals('davert');
             $this->assertInstanceOf('demo\UserModel', $user);
-        });
+            //});
 
-        $this->specify('instance can be created without constructor', function() {
+            //$this->specify('instance can be created without constructor', function() {
             $user = $this->class->make();
             $this->assertInstanceOf('demo\UserModel', $user);
-        });
+            //});
     }
 
     public function testClassWithTraits() {

--- a/tests/unit/FunctionInjectorTest.php
+++ b/tests/unit/FunctionInjectorTest.php
@@ -8,7 +8,7 @@ use AspectMock\Intercept\FunctionInjector;
 use AspectMock\Test as test;
 use PHPUnit\Framework\ExpectationFailedException;
 
-final class FunctionInjectorTest extends \Codeception\TestCase\Test
+final class FunctionInjectorTest extends \Codeception\Test\Unit
 {
     protected FunctionInjector $funcInjector;
 
@@ -34,7 +34,7 @@ final class FunctionInjectorTest extends \Codeception\TestCase\Test
     public function testReferencedParameterTemplate()
     {
         $php = $this->funcReferencedParameterInjector->getPHP();
-        verify($php)->stringContainsString("function preg_match(\$p0, \$p1, &\$p2=NULL, \$p3=NULL, \$p4=NULL)");
+        verify($php)->stringContainsString("function preg_match(string \$p0, string \$p1, &\$p2 = null, int \$p3 = 0, int \$p4 = 0)");
         verify($php)->stringContainsString("case 5: \$args = [\$p0, \$p1, &\$p2, \$p3, \$p4]; break;");
         verify($php)->stringContainsString("case 4: \$args = [\$p0, \$p1, &\$p2, \$p3]; break;");
         verify($php)->stringContainsString("case 3: \$args = [\$p0, \$p1, &\$p2]; break;");

--- a/tests/unit/MockTest.php
+++ b/tests/unit/MockTest.php
@@ -25,18 +25,18 @@ final class MockTest extends TestCase
         $user = new InstanceProxy($user);
         $user->setName('davert');
 
-        $this->specify('setName() was invoked', function() use ($user) {
+        //$this->specify('setName() was invoked', function() use ($user) {
             $user->verifyInvoked('setName');
             $user->verifyInvoked('setName',['davert']);
             $user->verifyInvokedMultipleTimes('setName',1);
             $user->verifyInvokedMultipleTimes('setName',1,['davert']);
             $user->verifyNeverInvoked('setName',['bugoga']);
-        });
+            //});
 
-        $this->specify('save() was not invoked', function() use ($user) {
+            //$this->specify('save() was not invoked', function() use ($user) {
             $user->verifyNeverInvoked('save');
             $user->verifyNeverInvoked('save',['params']);
-        });
+            //});
     }
 
     public function testVerifyClassMethods()

--- a/tests/unit/VerifierTest.php
+++ b/tests/unit/VerifierTest.php
@@ -41,15 +41,15 @@ final class VerifierTest extends TestCase
             verify($empty)->empty();
         };
 
-        $this->specify('closure was called', function() use ($user, $info, $matcher) {
+        //$this->specify('closure was called', function() use ($user, $info, $matcher) {
             $user->verifyInvokedMultipleTimes('setInfo', 2, $matcher);
             $user->verifyInvoked('setInfo', $matcher);
-        });
+            //});
     }
 
     public function testVerifyMagicMethods()
     {
-        $this->specify('works for class proxy', function() {
+      //$this->specify('works for class proxy', function() {
             // Set up user object.
             double::registerClass("demo\UserModel",
                                   ['renameUser'=>"Bob Jones", 'save'=>null]);
@@ -61,9 +61,9 @@ final class VerifierTest extends TestCase
 
             // Assert rename was counted.
             $userProxy->verifyInvoked('renameUser');
-        });
+            //});
 
-        $this->specify('works for instance proxy', function() {
+            //$this->specify('works for instance proxy', function() {
             // Set up user object.
             $user = new UserModel(['name'=>"John Smith"]);
             double::registerObject($user);
@@ -74,12 +74,12 @@ final class VerifierTest extends TestCase
 
             // Assert rename was counted.
             $user->verifyInvoked('renameUser');
-        });
+            //});
     }
 
     public function testverifyWithMutliplesParams()
     {
-        $this->specify('works for instance proxy', function () {
+      //$this->specify('works for instance proxy', function () {
             // Set up user object.
             $user = new UserModel(['name' => "John Smith"]);
             double::registerObject($user);
@@ -113,6 +113,6 @@ final class VerifierTest extends TestCase
             } catch (Exception $e) {
 
             }
-        });
+            //});
     }
 }

--- a/tests/unit/testDoubleTest.php
+++ b/tests/unit/testDoubleTest.php
@@ -27,10 +27,10 @@ final class testDoubleTest extends Unit
         UserModel::tableName();
         $user->verifyInvokedMultipleTimes('tableName',2);
 
-        $this->specify('disabling all methods', function() use ($user) {
+        //$this->specify('disabling all methods', function() use ($user) {
             test::methods($user, []);
             verify(UserModel::tableName())->null();
-        });
+            //});
     }
 
     public function testDoubleFullyQualifiedClass()
@@ -42,10 +42,10 @@ final class testDoubleTest extends Unit
         UserModel::tableName();
         $user->verifyInvokedMultipleTimes('tableName',2);
 
-        $this->specify('disabling all methods', function() use ($user) {
+        //$this->specify('disabling all methods', function() use ($user) {
             test::methods($user, []);
             verify(UserModel::tableName())->null();
-        });
+            //});
     }
 
     public function testDoubleObject()
@@ -55,13 +55,13 @@ final class testDoubleTest extends Unit
         $user->save();
         $user->verifyInvoked('save');
 
-        $this->specify('only selected methods can be added to instance', function() use ($user) {
+        //$this->specify('only selected methods can be added to instance', function() use ($user) {
             $user = test::methods($user, ['setName']);
             $user->setName('davert');
             verify($user->getName())->notEquals('davert');
             verify($user->getName())->null();
             verify($user->getObject()->getName())->null();
-        });
+            //});
     }
 
     public function testSpecUndefinedClass()
@@ -75,39 +75,39 @@ final class testDoubleTest extends Unit
         $this->any = $class->make();
         $this->any = $class->construct();
 
-        $this->specify('should return original class name', function() {
+        //$this->specify('should return original class name', function() {
             $this->assertStringContainsString('Undefined', (string)$this->any);
             $this->assertStringContainsString('MyVirtualClass', (string)$this->any->__toString());
-        });
+            //});
 
-        $this->specify('any method can be invoked', function() {
+            //$this->specify('any method can be invoked', function() {
            $this->assertInstanceOf('AspectMock\Proxy\Anything', $this->any->doSmth()->withTHis()->andThatsAll()->null());
-        });
+           //});
 
-        $this->specify('any property can be accessed', function() {
+           //$this->specify('any property can be accessed', function() {
             $this->any->that = 'xxx';
            $this->assertInstanceOf('AspectMock\Proxy\Anything', $this->any->this->that->another);
-        });
+           //});
 
-        $this->specify('can be used as array', function() {
+           //$this->specify('can be used as array', function() {
             $this->any['has keys'];
             unset($this->any['this']);
             $this->any['this'] = 'that';
             $this->assertFalse(isset($this->any['that']));
             $this->assertInstanceOf('AspectMock\Proxy\Anything', $this->any['keys']);
-        });
+            //});
 
-        $this->specify('can be iterated', function() {
+            //$this->specify('can be iterated', function() {
             foreach ($this->any as $anything) {}
-        });
+            //});
 
-        $this->specify('proxifies magic method calls', function() {
+            //$this->specify('proxifies magic method calls', function() {
             $any = test::double($this->any);
             $any->callMeMaybe();
             $any->name = 'hello world';
             $this->assertInstanceOf('AspectMock\Proxy\Anything', $any->name);
             verify($any->class->className)->equals('AspectMock\Proxy\Anything');
-        });
+            //});
     }
 
     public function testCleanupSpecificClasses()


### PR DESCRIPTION
Hello,

Recent changes in the master branch of `goap/framework` pushed `symfony/finder` forward and this branch no longer works.

Updating the dependencies brought issues with Specify and PHPUnit 10.

From what I can tell, that is not solved. This is unrelated to this project, just it tests so I commented out the Specify calls, leaving the asserts as part of the base test function.

A fix for #201 is also included. Tested with PHP 8 under Debian Trixie.
