### PR TITLE
Switch goaop packages from dev to stable versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
        },
     "require": {
         "php": "^8.2",
-        "goaop/framework": "^4.0@dev",
-        "goaop/parser-reflection": "^4.0@dev",
+        "goaop/framework": "^3.1.1",
         "phpunit/phpunit": "^9.5",
         "symfony/finder": "^4.4 | ^5.4 | ^6.0"
     },


### PR DESCRIPTION
These are compatible with PHP 8.2 just like AspectMock currently is